### PR TITLE
Fixed missing options extend parameter.

### DIFF
--- a/src/js/multiLineEllipsis.js
+++ b/src/js/multiLineEllipsis.js
@@ -3,7 +3,7 @@
         var settings = $.extend({
             line:2,
             tooltip:true
-        });
+        }, options);
         this.each(function(){
             applyEllipsis(this,this.offsetWidth,settings.line,settings.tooltip);
         });


### PR DESCRIPTION
Hi there, jquery extend parameter was missing, so setting "line" parameter did not work.
Regards.